### PR TITLE
#163180419 make queryBuilder parameter arguement string by default

### DIFF
--- a/src/database/queryBuilder.js
+++ b/src/database/queryBuilder.js
@@ -6,7 +6,7 @@ const pool = new Pool({
 });
 
 class QueryBuilder {
-	run(statement, parameters){
+	run(statement, parameters = ''){
 		return new Promise((resolve, reject) => {
 			pool.query(statement)
 			.then(response => {


### PR DESCRIPTION
#### What does this PR do?
Makes a method argument default to string

#### Description of Task to be completed?
Ensures the querybuilder class argument for the run method defaults to string

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?(if applicable)
https://www.pivotaltracker.com/story/show/163180419

#### Screenshots